### PR TITLE
Alb.tf update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # How to deploy a three-tier architecture in AWS using Terraform?
 
-### What is Terraform?
+### What is Terraform (IaC tool)?
 
 Terraform is an open-source infrastructure as a code (IAC) tool that allows to create, manage & deploy the production-ready environment. Terraform codifies cloud APIs into declarative configuration files. Terraform can manage both existing service providers and custom in-house solutions.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # How to deploy a three-tier architecture in AWS using Terraform?
 
-### What is Terraform (IaC tool)?
+### What is Terraform ?
 
 Terraform is an open-source infrastructure as a code (IAC) tool that allows to create, manage & deploy the production-ready environment. Terraform codifies cloud APIs into declarative configuration files. Terraform can manage both existing service providers and custom in-house solutions.
 

--- a/Terraform-Cofigs/alb.tf
+++ b/Terraform-Cofigs/alb.tf
@@ -24,7 +24,7 @@ resource "aws_lb_target_group_attachment" "attachment" {
   ]
 }
 
-resource "aws_lb_target_group_attachment" "attachment" {
+resource "aws_lb_target_group_attachment" "attachment1" {
   target_group_arn = aws_lb_target_group.external-alb.arn
   target_id        = aws_instance.demoinstance1.id
   port             = 80

--- a/Terraform-Cofigs/rds.tf
+++ b/Terraform-Cofigs/rds.tf
@@ -15,7 +15,7 @@ resource "aws_db_instance" "default" {
   engine_version         = "8.0.20"
   instance_class         = "db.t2.micro"
   multi_az               = true
-  name                   = "mydb"
+  db_name                = "mydb"
   username               = "username"
   password               = "password"
   skip_final_snapshot    = true


### PR DESCRIPTION
│ Error: Duplicate resource "aws_lb_target_group_attachment" configuration
│
│   on alb.tf line 27:
│   27: resource "aws_lb_target_group_attachment" "attachment" {
│
│ A aws_lb_target_group_attachment resource named "attachment" was already declared at alb.tf:17,1-55. Resource names must be unique per type in each module.


Terraform plan retruned above error. Updated second attachment from <<resource "aws_lb_target_group_attachment" "attachment">> to <<resource "aws_lb_target_group_attachment" "attachment1">>